### PR TITLE
Ensure that Figjam.adapter is set to Figjam::Rails::Application before the figjam Railtie is loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ build-iPhoneSimulator/
 
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*
+/spec/internal/log/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,10 @@ GEM
     childprocess (4.1.0)
     coderay (1.1.3)
     colorize (0.8.1)
+    combustion (1.3.7)
+      activesupport (>= 3.0.0)
+      railties (>= 3.0.0)
+      thor (>= 0.14.6)
     concurrent-ruby (1.1.10)
     contracts (0.16.1)
     crass (1.0.6)
@@ -248,6 +252,7 @@ DEPENDENCIES
   appraisal
   aruba
   bundler
+  combustion
   fasterer
   figjam!
   pry-byebug

--- a/figjam.gemspec
+++ b/figjam.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "aruba"
   spec.add_development_dependency "bundler"
+  spec.add_development_dependency "combustion"
   spec.add_development_dependency "fasterer"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake"

--- a/gemfiles/rails_5_2.gemfile.lock
+++ b/gemfiles/rails_5_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    figjam (1.3.0)
+    figjam (1.4.0)
       thor (>= 0.14.0, < 2)
 
 GEM
@@ -66,6 +66,10 @@ GEM
     childprocess (4.1.0)
     coderay (1.1.3)
     colorize (0.8.1)
+    combustion (1.3.7)
+      activesupport (>= 3.0.0)
+      railties (>= 3.0.0)
+      thor (>= 0.14.6)
     concurrent-ruby (1.1.10)
     contracts (0.16.1)
     crass (1.0.6)
@@ -218,6 +222,7 @@ DEPENDENCIES
   appraisal
   aruba
   bundler
+  combustion
   fasterer
   figjam!
   pry-byebug

--- a/gemfiles/rails_6.gemfile.lock
+++ b/gemfiles/rails_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    figjam (1.3.0)
+    figjam (1.4.0)
       thor (>= 0.14.0, < 2)
 
 GEM
@@ -79,6 +79,10 @@ GEM
     childprocess (4.1.0)
     coderay (1.1.3)
     colorize (0.8.1)
+    combustion (1.3.7)
+      activesupport (>= 3.0.0)
+      railties (>= 3.0.0)
+      thor (>= 0.14.6)
     concurrent-ruby (1.1.10)
     contracts (0.16.1)
     crass (1.0.6)
@@ -234,6 +238,7 @@ DEPENDENCIES
   appraisal
   aruba
   bundler
+  combustion
   fasterer
   figjam!
   pry-byebug

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    figjam (1.3.0)
+    figjam (1.4.0)
       thor (>= 0.14.0, < 2)
 
 GEM
@@ -83,6 +83,10 @@ GEM
     childprocess (4.1.0)
     coderay (1.1.3)
     colorize (0.8.1)
+    combustion (1.3.7)
+      activesupport (>= 3.0.0)
+      railties (>= 3.0.0)
+      thor (>= 0.14.6)
     concurrent-ruby (1.1.10)
     contracts (0.16.1)
     crass (1.0.6)
@@ -237,6 +241,7 @@ DEPENDENCIES
   appraisal
   aruba
   bundler
+  combustion
   fasterer
   figjam!
   pry-byebug

--- a/gemfiles/rails_7.gemfile.lock
+++ b/gemfiles/rails_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    figjam (1.3.0)
+    figjam (1.4.0)
       thor (>= 0.14.0, < 2)
 
 GEM
@@ -89,6 +89,10 @@ GEM
     childprocess (4.1.0)
     coderay (1.1.3)
     colorize (0.8.1)
+    combustion (1.3.7)
+      activesupport (>= 3.0.0)
+      railties (>= 3.0.0)
+      thor (>= 0.14.6)
     concurrent-ruby (1.1.10)
     contracts (0.16.1)
     crass (1.0.6)
@@ -245,6 +249,7 @@ DEPENDENCIES
   appraisal
   aruba
   bundler
+  combustion
   fasterer
   figjam!
   pry-byebug

--- a/lib/figjam/rails.rb
+++ b/lib/figjam/rails.rb
@@ -5,8 +5,8 @@ begin
 rescue LoadError
 else
   require "figjam/rails/application"
-  require "figjam/rails/railtie"
 
   Figjam.adapter = Figjam::Rails::Application
+  require "figjam/rails/railtie"
 end
 

--- a/spec/figjam/rails_spec.rb
+++ b/spec/figjam/rails_spec.rb
@@ -45,6 +45,10 @@ describe Figjam::Rails do
 development:
   adapter: sqlite3
   database: db/<%= ENV["foo"] %>.sqlite3
+
+test:
+  adapter: sqlite3
+  database: db/<%= ENV["foo"] %>.sqlite3
 EOF
 
       run_command_and_stop("rake db:migrate")

--- a/spec/figjam_spec.rb
+++ b/spec/figjam_spec.rb
@@ -60,6 +60,12 @@ describe Figjam do
     end
   end
 
+  describe "railtie configuration" do
+    it "loads railtie after the adapter is set to Figaro::Rails::Application" do
+      expect(ENV['ENGINE_VALUE']).to eq('diesel')
+    end
+  end
+
   describe ".require_keys" do
     before do
       ::ENV["foo"] = "bar"

--- a/spec/internal/config/application.yml
+++ b/spec/internal/config/application.yml
@@ -1,0 +1,1 @@
+ENGINE_VALUE: diesel

--- a/spec/internal/config/initializers/initialize_figaro.rb
+++ b/spec/internal/config/initializers/initialize_figaro.rb
@@ -1,0 +1,7 @@
+require 'figaro'
+
+Figaro.application = Figaro::Application.new(
+  environment: ::Rails.env,
+  path: File.expand_path('../application.yml', File.dirname(__FILE__))
+)
+Figaro.load

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,12 @@
 require "bundler"
 Bundler.setup
 
+# This block of code helps to test the Railtie initialisation order. It cannot go directly in a spec
+# as it is about how gems are required.
+require 'rails'
+require 'combustion'
+Combustion.initialize!
+
 require "figjam"
 require "pry-byebug"
 


### PR DESCRIPTION
Figjam should be able to be used in the initializer of a Rails engine. When testing the engine using a tool like [Combustion](https://github.com/pat/combustion), we see that the Railtie to load Figjam is added immediately after the definition of `Figjam::Rails::Application`.

This can (and sometimes does) mean that the `before_configuration` block of that Railtie is immediately executed. At this point, the `Figjam.adapter` is still `nil`, so it is lazily created as a `Figjam::Application`. The Railtie then calls `Figjam.load` on it, and it blows up as `default_path` throws a `NotImplementedError`.

The solution is to set the adapter to a `Figjam::Rails::Application` as soon as possible, and before the Railtie is created.

This PR makes that 2 line swap change, and adds Combustion to the specs. If the two lines of logic are not swapped, you can see how the initializing process fails.