### PR TITLE
Allow silencing of non-string configuration warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Ensure that Figjam.adapter is set to Figjam::Rails::Application before the figjam Railtie is loaded [#7](https://github.com/hlascelles/figjam/pull/7)
+- Allow silencing of non-string configuration warnings [#8](https://github.com/hlascelles/figjam/pull/8)
 
 ## 1.4.0 (2022-11-14)
 

--- a/lib/figjam/application.rb
+++ b/lib/figjam/application.rb
@@ -5,6 +5,10 @@ require "figjam/figaro_alias"
 module Figjam
   class Application
     FIGARO_ENV_PREFIX = "_FIGARO_"
+    SILENCE_STRING_WARNINGS_KEYS = %i[
+      FIGARO_SILENCE_STRING_WARNINGS
+      FIGJAM_SILENCE_STRING_WARNINGS
+    ]
 
     include Enumerable
 
@@ -70,8 +74,10 @@ module Figjam
     end
 
     def set(key, value)
-      non_string_configuration!(key) unless key.is_a?(String)
-      non_string_configuration!(value) unless value.is_a?(String) || value.nil?
+      unless non_string_warnings_silenced?
+        non_string_configuration!(key) unless key.is_a?(String)
+        non_string_configuration!(value) unless value.is_a?(String) || value.nil?
+      end
 
       ::ENV[key.to_s] = value.nil? ? nil : value.to_s
       ::ENV[FIGARO_ENV_PREFIX + key.to_s] = value.nil? ? nil: value.to_s
@@ -79,6 +85,13 @@ module Figjam
 
     def skip?(key)
       ::ENV.key?(key.to_s) && !::ENV.key?(FIGARO_ENV_PREFIX + key.to_s)
+    end
+
+    def non_string_warnings_silenced?
+      SILENCE_STRING_WARNINGS_KEYS.any? { |key|
+        # Allow the silence configuration itself to use non-string keys/values.
+        configuration.values_at(key.to_s, key).any? { |cv| cv.to_s == 'true' }
+      }
     end
 
     def non_string_configuration!(value)

--- a/spec/figjam/application_spec.rb
+++ b/spec/figjam/application_spec.rb
@@ -232,20 +232,57 @@ test:
       }.from("bar").to("baz")
     end
 
-    it "warns when a key isn't a string" do
-      allow(application).to receive(:configuration) { { foo: "bar" } }
+    shared_examples 'correct warning with and without silence override' do
+      [
+        { FIGARO_SILENCE_STRING_WARNINGS: true },
+        { 'FIGARO_SILENCE_STRING_WARNINGS' => true },
+        { FIGARO_SILENCE_STRING_WARNINGS: 'true' },
+        { 'FIGARO_SILENCE_STRING_WARNINGS' => 'true' },
+        { FIGJAM_SILENCE_STRING_WARNINGS: true },
+        { 'FIGJAM_SILENCE_STRING_WARNINGS' => true },
+        { FIGJAM_SILENCE_STRING_WARNINGS: 'true' },
+        { 'FIGJAM_SILENCE_STRING_WARNINGS' => 'true' },
+      ].each do |override|
+        it "does not warn with override #{override.inspect}" do
+          allow(application).to receive(:configuration) { config.merge(override) }
 
-      expect(application).to receive(:warn)
+          expect(application).to_not receive(:warn)
 
-      application.load
+          application.load
+        end
+      end
+
+      [
+        [{ }, 1],
+        [{ 'FIGARO_SILENCE_STRING_WARNINGS' => false }, 2],
+        [{ FIGARO_SILENCE_STRING_WARNINGS: false }, 3],
+        [{ 'FIGARO_SILENCE_STRING_WARNINGS' => 'false' }, 1],
+        [{ FIGARO_SILENCE_STRING_WARNINGS: 'false' }, 2],
+        [{ 'FIGJAM_SILENCE_STRING_WARNINGS' => false }, 2],
+        [{ FIGJAM_SILENCE_STRING_WARNINGS: false }, 3],
+        [{ 'FIGJAM_SILENCE_STRING_WARNINGS' => 'false' }, 1],
+        [{ FIGJAM_SILENCE_STRING_WARNINGS: 'false' }, 2],
+      ].each do |override, expected_warning_count|
+        it "warns #{expected_warning_count} times with override #{override.inspect}" do
+          allow(application).to receive(:configuration) { config.merge(override) }
+
+          expect(application).to receive(:warn).exactly(expected_warning_count).times
+
+          application.load
+        end
+      end
     end
 
-    it "warns when a value isn't a string" do
-      allow(application).to receive(:configuration) { { "foo" => ["bar"] } }
+    context "warning when a key isn't a string" do
+      let(:config) { { SYMBOL_KEY: 'string value' } }
 
-      expect(application).to receive(:warn)
+      include_examples "correct warning with and without silence override"
+    end
 
-      application.load
+    context "warning when a value isn't a string" do
+      let(:config) { { 'string key' => :SYMBOL_VALUE } }
+
+      include_examples "correct warning with and without silence override"
     end
 
     it "allows nil values" do


### PR DESCRIPTION
This adds a new configuration entry, `FIGJAM_SILENCE_STRING_WARNINGS`, which if set to `true`/`true` will silence warnings like `WARNING: Use strings for Figaro configuration. 100 was converted to "100"`.

eg:
```yaml
FIGJAM_SILENCE_STRING_WARNINGS: true

# These will now not cause a warning log lines:
FOO: 1
BAR: true
```

`FIGARO_SILENCE_STRING_WARNINGS` is also supported.

Thanks to @owst for offering this fix in the original Figaro gem: https://github.com/laserlemon/figaro/pull/264