### PR TITLE
Support Psych 4.X+ to correctly handle YAML aliases, fixes #15

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -13,3 +13,18 @@ end
 appraise "rails-7" do
   gem "rails", "~> 7.0"
 end
+
+appraise "psych-3.3" do
+  gem "rails", "~> 7.0"
+  gem "psych", "~> 3.3"
+end
+
+appraise "psych-4.0" do
+  gem "rails", "~> 7.0"
+  gem "psych", "~> 4.0"
+end
+
+appraise "psych-5.0" do
+  gem "rails", "~> 7.0"
+  gem "psych", "~> 5.0"
+end

--- a/lib/figjam/application.rb
+++ b/lib/figjam/application.rb
@@ -62,7 +62,17 @@ module Figjam
     end
 
     def parse(path)
-      File.exist?(path) && YAML.load(ERB.new(File.read(path)).result) || {}
+      File.exist?(path) && load_yaml(ERB.new(File.read(path)).result) || {}
+    end
+
+    def load_yaml(source)
+      # https://bugs.ruby-lang.org/issues/17866
+      # https://github.com/rails/rails/commit/179d0a1f474ada02e0030ac3bd062fc653765dbe
+      begin
+        YAML.load(source, aliases: true) || {}
+      rescue ArgumentError
+        YAML.load(source) || {}
+      end
     end
 
     def global_configuration

--- a/spec/figjam_spec.rb
+++ b/spec/figjam_spec.rb
@@ -60,6 +60,12 @@ describe Figjam do
     end
   end
 
+  describe "#configuration" do
+    it "includes configuration using YAML aliases" do
+      expect(ENV['WHEEL_COUNT']).to eq('4')
+    end
+  end
+
   describe "railtie configuration" do
     it "loads railtie after the adapter is set to Figaro::Rails::Application" do
       expect(ENV['ENGINE_VALUE']).to eq('diesel')

--- a/spec/internal/config/application.yml
+++ b/spec/internal/config/application.yml
@@ -1,1 +1,7 @@
 ENGINE_VALUE: diesel
+
+test_default: &test_default
+  WHEEL_COUNT: "4"
+
+test:
+  <<: *test_default


### PR DESCRIPTION
Psych 4 uses `safe_load` by default (which doesn't allow aliases)