### PR TITLE
Enforce uppercase ENV keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0 (2025-04-12)
+
+BREAKING CHANGE:
+- Enforce uppercase ENV keys [#184](https://github.com/hlascelles/figjam/pull/184)
+
 ## 1.6.2 (2024-09-10)
 
 - Reduce override log level to info [#160](https://github.com/hlascelles/figjam/pull/160)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    figjam (1.6.2)
+    figjam (2.0.0)
       thor (>= 0.14.0, < 2)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ figjam
 [![specs workflow](https://github.com/hlascelles/figjam/actions/workflows/specs.yml/badge.svg)](https://github.com/hlascelles/figjam/actions)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-
 Figjam makes it easy to configure ruby and Rails apps `ENV` values by just using a single YAML file.
 
 PRs to applications often need to come with default configuration values, but hardcoding these into

--- a/lib/figjam/version.rb
+++ b/lib/figjam/version.rb
@@ -1,3 +1,3 @@
 module Figjam
-  VERSION = "1.6.2".freeze
+  VERSION = "2.0.0".freeze
 end

--- a/spec/figjam/rails_spec.rb
+++ b/spec/figjam/rails_spec.rb
@@ -44,11 +44,11 @@ describe Figjam::Rails do
 
   describe "initialization" do
     before do
-      write_file("config/application.yml", "foo: bar")
+      write_file("config/application.yml", "FOO: bar")
     end
 
     it "loads application.yml" do
-      run_command_and_stop("rails runner 'puts Figjam.env.foo'")
+      run_command_and_stop("rails runner 'puts Figjam.env.FOO'")
 
       expect(all_stdout).to include("bar")
     end
@@ -57,11 +57,11 @@ describe Figjam::Rails do
       write_file("config/database.yml", <<~STR)
         development:
           adapter: sqlite3
-          database: db/<%= ENV["foo"] %>.sqlite3
+          database: db/<%= ENV["FOO"] %>.sqlite3
 
         test:
           adapter: sqlite3
-          database: db/<%= ENV["foo"] %>.sqlite3
+          database: db/<%= ENV["FOO"] %>.sqlite3
       STR
 
       run_command_and_stop("rake db:migrate")
@@ -71,10 +71,10 @@ describe Figjam::Rails do
 
     it "happens before application configuration" do
       insert_into_file_after("config/application.rb", /< Rails::Application$/, <<-STR)
-    config.foo = ENV["foo"]
+    config.FOO = ENV["FOO"]
       STR
 
-      run_command_and_stop("rails runner 'puts Rails.application.config.foo'")
+      run_command_and_stop("rails runner 'puts Rails.application.config.FOO'")
 
       expect(all_stdout).to include("bar")
     end


### PR DESCRIPTION
This is a breaking change that will enforce UPPERCASE ENV keys.

Valid:

```yaml
FOO: bar

test:
  FOO: baz
```

Invalid:
```yaml
foo: bar

test:
  foo: baz
```