### PR TITLE
Add Rails Engine helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0 (2025-07-16)
+
+- Add Rails Engine helper [#224](https://github.com/hlascelles/figjam/pull/224)
+
 ## 2.1.0 (2025-07-15)
 
 - Raise exception if config path is invalid [#223](https://github.com/hlascelles/figjam/pull/223)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    figjam (2.1.0)
+    figjam (2.2.0)
       thor (>= 0.14.0, < 2)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -59,14 +59,25 @@ overrides.
 
 Figjam is perfect for Rails engines. They can have their own configuration file, and
 they can be loaded independently or in addition of the main application. To do this,
-you can create a `config/application.yml` file in your engine, and add this initializer:
+you can create a `config/application.yml` file in your engine, and add this to the `Rails::Engine`:
 
 ```ruby
-Figjam::Application.new(
-  environment: ::Rails.env,
-  path: File.expand_path("../application.yml", __dir__)
-).load
+module MyEngine
+  class Engine < ::Rails::Engine
+    Figjam::Rails::Engine.configure(self)
+  end
+end
+
+# Or if you wish to pass in a specific value for the environment:
+module MyEngine
+  class Engine < ::Rails::Engine
+    Figjam::Rails::Engine.configure(self, "my_engine_environment")
+  end
+end
 ```
+
+This will ensure that the engine's configuration is loaded when the Rails application starts, and
+before any other initializers run.
 
 ### Usage without Rails
 

--- a/config/application.yml
+++ b/config/application.yml
@@ -1,1 +1,1 @@
-{} # Needed for testing the gem
+{}

--- a/gemfiles/psych_4.0.gemfile.lock
+++ b/gemfiles/psych_4.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    figjam (2.1.0)
+    figjam (2.2.0)
       thor (>= 0.14.0, < 2)
 
 GEM

--- a/gemfiles/psych_5.0.gemfile.lock
+++ b/gemfiles/psych_5.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    figjam (2.1.0)
+    figjam (2.2.0)
       thor (>= 0.14.0, < 2)
 
 GEM

--- a/gemfiles/rails_7.gemfile.lock
+++ b/gemfiles/rails_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    figjam (2.1.0)
+    figjam (2.2.0)
       thor (>= 0.14.0, < 2)
 
 GEM

--- a/gemfiles/rails_8.gemfile.lock
+++ b/gemfiles/rails_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    figjam (2.1.0)
+    figjam (2.2.0)
       thor (>= 0.14.0, < 2)
 
 GEM

--- a/lib/figjam/rails.rb
+++ b/lib/figjam/rails.rb
@@ -6,6 +6,7 @@ rescue LoadError
   # Cater for no Rails
 else
   require "figjam/rails/application"
+  require "figjam/rails/engine"
 
   Figjam.adapter = Figjam::Rails::Application
   require "figjam/rails/railtie"

--- a/lib/figjam/rails/engine.rb
+++ b/lib/figjam/rails/engine.rb
@@ -1,0 +1,16 @@
+module Figjam
+  module Rails
+    module Engine
+      class << self
+        def configure(engine_context, environment = ::Rails.env)
+          engine_context.config.before_configuration do
+            Figjam::Application.new(
+              environment: environment,
+              path: "#{engine_context.root}/config/application.yml"
+            ).load
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/figjam/version.rb
+++ b/lib/figjam/version.rb
@@ -1,3 +1,3 @@
 module Figjam
-  VERSION = "2.1.0".freeze
+  VERSION = "2.2.0".freeze
 end

--- a/spec/figjam/rails/engine_spec.rb
+++ b/spec/figjam/rails/engine_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+require "figjam/rails/engine"
+
+describe Figjam::Rails::Engine do
+  describe ".configure" do
+    let(:test_engine_class) do
+      Class.new(::Rails::Engine) do
+        def self.root
+          Pathname.new(File.expand_path("../../..", __dir__))
+        end
+      end
+    end
+
+    it "sets up before_configuration callback" do
+      expect(test_engine_class.config).to receive(:before_configuration).and_call_original
+      described_class.configure(test_engine_class, "test")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,6 @@
 require "bundler"
 Bundler.setup
 
-# This block of code helps to test the Railtie initialisation order. It cannot go directly in a spec
-# as it is about how gems are required.
-require "rails"
 require "combustion"
 Combustion.initialize!
 


### PR DESCRIPTION
Figjam is perfect for Rails engines. They can have their own configuration file, and they can be loaded independently or in addition of the main application. To do this, you can create a `config/application.yml` file in your engine, and add this to the `Rails::Engine`:

```ruby
module MyEngine
  class Engine < ::Rails::Engine
    Figjam::Rails::Engine.configure(self)
  end
end

# Or if you wish to pass in a specific value for the environment:
module MyEngine
  class Engine < ::Rails::Engine
    Figjam::Rails::Engine.configure(self, "my_engine_environment")
  end
end
```